### PR TITLE
Treat more special characters as trailing delimiters (#3)

### DIFF
--- a/src/main/java/org/nibor/autolink/internal/UrlScanner.java
+++ b/src/main/java/org/nibor/autolink/internal/UrlScanner.java
@@ -54,6 +54,7 @@ public class UrlScanner implements Scanner {
         int round = 0;
         int square = 0;
         int curly = 0;
+        int angle = 0;
         boolean doubleQuote = false;
         boolean singleQuote = false;
         int last = beginIndex;
@@ -67,13 +68,22 @@ public class UrlScanner implements Scanner {
                 case '\u000B':
                 case '\f':
                 case '\r':
+                    // These can never be part of an URL, so stop now
                     break loop;
                 case '?':
                 case '!':
                 case '.':
                 case ',':
                 case ':':
+                case ';':
+                    // These may be part of an URL but not at the end
                     continue loop;
+                case '/':
+                    // This may be part of an URL and at the end, but not if the previous character can't be the end of an URL
+                    if (last != i - 1) {
+                        continue loop;
+                    }
+                    break;
                 case '(':
                     round++;
                     break;
@@ -92,6 +102,12 @@ public class UrlScanner implements Scanner {
                 case '}':
                     curly--;
                     break;
+                case '<':
+                    angle++;
+                    break;
+                case '>':
+                    angle--;
+                    break;
                 case '"':
                     doubleQuote = !doubleQuote;
                     break;
@@ -102,7 +118,7 @@ public class UrlScanner implements Scanner {
                     last = i;
                     continue loop;
             }
-            if (round >= 0 && square >= 0 && curly >= 0 && !doubleQuote && !singleQuote) {
+            if (round >= 0 && square >= 0 && curly >= 0 && angle >= 0 && !doubleQuote && !singleQuote) {
                 last = i;
             }
         }

--- a/src/test/java/org/nibor/autolink/AutolinkUrlTest.java
+++ b/src/test/java/org/nibor/autolink/AutolinkUrlTest.java
@@ -87,6 +87,7 @@ public class AutolinkUrlTest extends AutolinkTestCase {
         assertLinked("http://example.org/:", "|http://example.org/|:");
         assertLinked("http://example.org/?", "|http://example.org/|?");
         assertLinked("http://example.org/!", "|http://example.org/|!");
+        assertLinked("http://example.org/;", "|http://example.org/|;");
     }
 
     @Test
@@ -94,6 +95,7 @@ public class AutolinkUrlTest extends AutolinkTestCase {
         assertLinked("http://example.org/a(b)", "|http://example.org/a(b)|");
         assertLinked("http://example.org/a[b]", "|http://example.org/a[b]|");
         assertLinked("http://example.org/a{b}", "|http://example.org/a{b}|");
+        assertLinked("http://example.org/a<b>", "|http://example.org/a<b>|");
         assertLinked("http://example.org/a\"b\"", "|http://example.org/a\"b\"|");
         assertLinked("http://example.org/a'b'", "|http://example.org/a'b'|");
         assertLinked("(http://example.org/)", "(|http://example.org/|)");
@@ -110,9 +112,31 @@ public class AutolinkUrlTest extends AutolinkTestCase {
         assertLinked("[(http://example.org/)]", "[(|http://example.org/|)]");
         assertLinked("(http://example.org/).", "(|http://example.org/|).");
         assertLinked("(http://example.org/.)", "(|http://example.org/|.)");
+        assertLinked("http://example.org/>", "|http://example.org/|>");
         // not sure about these:
         assertLinked("http://example.org/(", "|http://example.org/(|");
         assertLinked("http://example.org/]()", "|http://example.org/|]()");
+    }
+
+    @Test
+    public void html() {
+        assertLinked("http://example.org\">", "|http://example.org|\">");
+        assertLinked("http://example.org'>", "|http://example.org|'>");
+        assertLinked("http://example.org\"/>", "|http://example.org|\"/>");
+        assertLinked("http://example.org'/>", "|http://example.org|'/>");
+    }
+
+    @Test
+    public void css() {
+        assertLinked("http://example.org\");", "|http://example.org|\");");
+        assertLinked("http://example.org');", "|http://example.org|');");
+    }
+
+    @Test
+    public void slash() {
+        assertLinked("http://example.org/", "|http://example.org/|");
+        assertLinked("http://example.org/a/", "|http://example.org/a/|");
+        assertLinked("http://example.org//", "|http://example.org//|");
     }
 
     @Test


### PR DESCRIPTION
* `;` is now treated the same as `,` and `:`
* `<` and `>` now also need to match, same as other brackets
* `/` can still be within or at the end of an URL, but if it's within a
  group of other delimiters, it behaves as a delimiter

Together, these new rules result in `">`, `"/>` and `");` to be excluded
at the end of links, while hopefully not messing with the overall
heuristics too much.