### PR TITLE
add non-breaking space to stop symbols list

### DIFF
--- a/src/main/java/org/nibor/autolink/internal/Scanners.java
+++ b/src/main/java/org/nibor/autolink/internal/Scanners.java
@@ -97,6 +97,7 @@ public class Scanners {
                 case '\u009D':
                 case '\u009E':
                 case '\u009F':
+                case '\u00A0': //non-breaking space
                     // These can never be part of an URL, so stop now. See RFC 3986 and RFC 3987.
                     // Some characters are not in the above list, even they are not in "unreserved" or "reserved":
                     //   '"', '\\', '^', '`', '{', '|', '}'


### PR DESCRIPTION
non-breaking space symbol is not allowed in url