### PR TITLE
Add extractSpans method so that we can deprecate renderLinks (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `extractSpans` method that also returns the text pieces of the
+  input before, between and after links. This makes it more convenient
+  to write code that transforms the whole input text without having to
+  manually keep track of indexes.
 ### Changed
+- Deprecated `Autolink.renderLinks` and `LinkRenderer`, see "added".
 - Stop URLs when encountering an `"`. This is consistent with RFC 3986,
   and it seems unlikely that a user would have an unescaped `"` in a URL
   anyway, as browsers escape it when you copy an URL that contains one.

--- a/src/main/java/org/nibor/autolink/Autolink.java
+++ b/src/main/java/org/nibor/autolink/Autolink.java
@@ -13,7 +13,9 @@ public class Autolink {
      * @param links the links to render, see {@link LinkExtractor} to extract them
      * @param linkRenderer the link rendering implementation
      * @return the rendered string
+     * @deprecated use {@link LinkExtractor#extractSpans(CharSequence)} instead
      */
+    @Deprecated
     public static String renderLinks(CharSequence input, Iterable<LinkSpan> links, LinkRenderer linkRenderer) {
         if (input == null) {
             throw new NullPointerException("input must not be null");

--- a/src/main/java/org/nibor/autolink/LinkRenderer.java
+++ b/src/main/java/org/nibor/autolink/LinkRenderer.java
@@ -1,8 +1,11 @@
 package org.nibor.autolink;
 
 /**
- * Renderer for a link.
+ * Renderer for a link
+ *
+ * @deprecated use {@link LinkExtractor#extractSpans(CharSequence)} instead.
  */
+@Deprecated
 public interface LinkRenderer {
 
     /**

--- a/src/main/java/org/nibor/autolink/LinkSpan.java
+++ b/src/main/java/org/nibor/autolink/LinkSpan.java
@@ -3,22 +3,11 @@ package org.nibor.autolink;
 /**
  * Information for an extracted link.
  */
-public interface LinkSpan {
+public interface LinkSpan extends Span {
 
     /**
      * @return the type of link
      */
     LinkType getType();
-
-    /**
-     * @return begin index (inclusive) in the original input that this link starts at
-     */
-    int getBeginIndex();
-
-    /**
-     * @return end index (exclusive) in the original input that this link ends at; in other words, index of first
-     * character after link
-     */
-    int getEndIndex();
 
 }

--- a/src/main/java/org/nibor/autolink/Span.java
+++ b/src/main/java/org/nibor/autolink/Span.java
@@ -1,0 +1,19 @@
+package org.nibor.autolink;
+
+/**
+ * A reference to a piece of the input text, either a link (see {@link LinkSpan}) or plain text.
+ */
+public interface Span {
+
+    /**
+     * @return begin index (inclusive) in the original input that this link starts at
+     */
+    int getBeginIndex();
+
+    /**
+     * @return end index (exclusive) in the original input that this link ends at; in other words, index of first
+     * character after link
+     */
+    int getEndIndex();
+
+}

--- a/src/main/java/org/nibor/autolink/internal/SpanImpl.java
+++ b/src/main/java/org/nibor/autolink/internal/SpanImpl.java
@@ -1,0 +1,29 @@
+package org.nibor.autolink.internal;
+
+import org.nibor.autolink.Span;
+
+public class SpanImpl implements Span {
+
+    private final int beginIndex;
+    private final int endIndex;
+
+    public SpanImpl(int beginIndex, int endIndex) {
+        this.beginIndex = beginIndex;
+        this.endIndex = endIndex;
+    }
+
+    @Override
+    public int getBeginIndex() {
+        return beginIndex;
+    }
+
+    @Override
+    public int getEndIndex() {
+        return endIndex;
+    }
+
+    @Override
+    public String toString() {
+        return "Span{beginIndex=" + beginIndex + ", endIndex=" + endIndex + "}";
+    }
+}

--- a/src/test/java/org/nibor/autolink/AutolinkBenchmark.java
+++ b/src/test/java/org/nibor/autolink/AutolinkBenchmark.java
@@ -32,7 +32,7 @@ public class AutolinkBenchmark extends AutolinkTestCase {
 
     @Benchmark
     public void generatedText() {
-        link(GENERATED_INPUT, "|", null);
+        renderExtractedLinks(GENERATED_INPUT, "|", null);
     }
 
     @Override

--- a/src/test/java/org/nibor/autolink/AutolinkTestCase.java
+++ b/src/test/java/org/nibor/autolink/AutolinkTestCase.java
@@ -5,18 +5,25 @@ import static org.junit.Assert.assertEquals;
 public abstract class AutolinkTestCase {
 
     protected void assertLinked(String input, String expected, LinkType expectedLinkType) {
-        String result = link(input, "|", expectedLinkType);
+        String result = renderExtractedLinks(input, "|", expectedLinkType);
         assertEquals(expected, result);
+
+        result = renderExtractedSpans(input, "|", expectedLinkType);
+        assertEquals(expected, result);
+
     }
 
     protected void assertNotLinked(String input) {
-        String result = link(input, "|", null);
+        String result = renderExtractedLinks(input, "|", null);
+        assertEquals(input, result);
+
+        result = renderExtractedSpans(input, "|", null);
         assertEquals(input, result);
     }
 
     protected abstract LinkExtractor getLinkExtractor();
 
-    protected String link(String input, final String marker, final LinkType expectedLinkType) {
+    protected String renderExtractedLinks(String input, final String marker, final LinkType expectedLinkType) {
         Iterable<LinkSpan> links = getLinkExtractor().extractLinks(input);
         return Autolink.renderLinks(input, links, new LinkRenderer() {
             @Override
@@ -29,6 +36,25 @@ public abstract class AutolinkTestCase {
                 sb.append(marker);
             }
         });
+    }
+
+    protected String renderExtractedSpans(String input, final String marker, final LinkType expectedLinkType) {
+        Iterable<Span> spans = getLinkExtractor().extractSpans(input);
+        StringBuilder sb = new StringBuilder();
+        for (Span span : spans) {
+            if (span instanceof LinkSpan) {
+                LinkType type = ((LinkSpan) span).getType();
+                if (expectedLinkType != null) {
+                    assertEquals(expectedLinkType, type);
+                }
+                sb.append(marker);
+                sb.append(input, span.getBeginIndex(), span.getEndIndex());
+                sb.append(marker);
+            } else {
+                sb.append(input, span.getBeginIndex(), span.getEndIndex());
+            }
+        }
+        return sb.toString();
     }
 
 }

--- a/src/test/java/org/nibor/autolink/LinkIterableTest.java
+++ b/src/test/java/org/nibor/autolink/LinkIterableTest.java
@@ -7,18 +7,18 @@ import java.util.NoSuchElementException;
 
 import static org.junit.Assert.*;
 
-public class LinkExtractorIterableTest {
+public class LinkIterableTest {
 
     @Test
     public void iteratorIsNew() {
-        Iterable<LinkSpan> iterable = getSingleElementIterable();
+        Iterable<LinkSpan> iterable = getSingleLinkIterable();
         assertEquals(LinkType.URL, iterable.iterator().next().getType());
         assertEquals(LinkType.URL, iterable.iterator().next().getType());
     }
 
     @Test
     public void hasNextOnlyAdvancesOnce() {
-        Iterable<LinkSpan> iterable = getSingleElementIterable();
+        Iterable<LinkSpan> iterable = getSingleLinkIterable();
         Iterator<LinkSpan> iterator = iterable.iterator();
         assertTrue(iterator.hasNext());
         assertTrue(iterator.hasNext());
@@ -29,7 +29,7 @@ public class LinkExtractorIterableTest {
 
     @Test(expected = NoSuchElementException.class)
     public void nextThrowsNoSuchElementException() {
-        Iterable<LinkSpan> iterable = getSingleElementIterable();
+        Iterable<LinkSpan> iterable = getSingleLinkIterable();
         Iterator<LinkSpan> iterator = iterable.iterator();
         assertNotNull(iterator.next());
         iterator.next();
@@ -37,11 +37,11 @@ public class LinkExtractorIterableTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void removeUnsupported() {
-        Iterable<LinkSpan> iterable = getSingleElementIterable();
+        Iterable<LinkSpan> iterable = getSingleLinkIterable();
         iterable.iterator().remove();
     }
 
-    private Iterable<LinkSpan> getSingleElementIterable() {
+    private Iterable<LinkSpan> getSingleLinkIterable() {
         String input = "foo http://example.com";
         return LinkExtractor.builder().build().extractLinks(input);
     }

--- a/src/test/java/org/nibor/autolink/SpanIterableTest.java
+++ b/src/test/java/org/nibor/autolink/SpanIterableTest.java
@@ -1,0 +1,68 @@
+package org.nibor.autolink;
+
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class SpanIterableTest {
+
+    @Test
+    public void iteratorIsNew() {
+        Iterable<Span> iterable = extractSpans("test");
+        assertEquals(4, iterable.iterator().next().getEndIndex());
+        assertEquals(4, iterable.iterator().next().getEndIndex());
+    }
+
+    @Test
+    public void hasNextOnlyAdvancesOnce() {
+        Iterable<Span> iterable = extractSpans("test");
+        Iterator<Span> iterator = iterable.iterator();
+        assertTrue(iterator.hasNext());
+        assertTrue(iterator.hasNext());
+        assertNotNull(iterator.next());
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void spanAndLinkSequences() {
+        assertEquals(Arrays.asList("test"),
+                extractSpansAsText("test"));
+        assertEquals(Arrays.asList("http://example.org"),
+                extractSpansAsText("http://example.org"));
+        assertEquals(Arrays.asList("test ", "http://example.org"),
+                extractSpansAsText("test http://example.org"));
+        assertEquals(Arrays.asList("http://example.org", " test"),
+                extractSpansAsText("http://example.org test"));
+        assertEquals(Arrays.asList("http://example.org", " ", "https://example.com"),
+                extractSpansAsText("http://example.org https://example.com"));
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void nextThrowsNoSuchElementException() {
+        Iterable<Span> iterable = extractSpans("test");
+        Iterator<Span> iterator = iterable.iterator();
+        assertNotNull(iterator.next());
+        iterator.next();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void removeUnsupported() {
+        Iterable<Span> iterable = extractSpans("test");
+        iterable.iterator().remove();
+    }
+
+    private Iterable<Span> extractSpans(String input) {
+        return LinkExtractor.builder().build().extractSpans(input);
+    }
+
+    private List<String> extractSpansAsText(String input) {
+        List<String> text = new ArrayList<>();
+        for (Span span : extractSpans(input)) {
+            text.add(input.substring(span.getBeginIndex(), span.getEndIndex()));
+        }
+        return text;
+    }
+}

--- a/src/test/java/org/nibor/autolink/UsageExampleTest.java
+++ b/src/test/java/org/nibor/autolink/UsageExampleTest.java
@@ -1,0 +1,48 @@
+package org.nibor.autolink;
+
+import org.junit.Test;
+
+import java.util.EnumSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class UsageExampleTest {
+
+    @Test
+    public void linkify() {
+        String input = "wow http://test.com such linked";
+        LinkExtractor linkExtractor = LinkExtractor.builder()
+                .linkTypes(EnumSet.of(LinkType.URL)) // limit to URLs
+                .build();
+        Iterable<Span> spans = linkExtractor.extractSpans(input);
+
+        StringBuilder sb = new StringBuilder();
+        for (Span span : spans) {
+            String text = input.substring(span.getBeginIndex(), span.getEndIndex());
+            if (span instanceof LinkSpan) {
+                // span is a URL
+                sb.append("<a href=\"");
+                sb.append(Encode.forHtmlAttribute(text));
+                sb.append("\">");
+                sb.append(Encode.forHtml(text));
+                sb.append("</a>");
+            } else {
+                // span is plain text before/after link
+                sb.append(Encode.forHtml(text));
+            }
+        }
+
+        assertEquals("wow <a href=\"http://test.com\">http://test.com</a> such linked", sb.toString());
+    }
+
+    // Mocked here to not have to depend on owasp-java-encoder in tests
+    private static class Encode {
+        public static String forHtmlAttribute(String text) {
+            return text;
+        }
+
+        public static String forHtml(String text) {
+            return text;
+        }
+    }
+}


### PR DESCRIPTION
With spans, the code for renderLinks can just be written as a normal
loop with an if statement. This makes it possible to render the text
between links in a special way too (e.g. escape it).

@mindhaq have a look at this (probably mostly the changed example in the README).