### PR TITLE
Modular JAR: Require at least Java 9 and add module-info module descriptor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [1.8, 11, 17]
+        java: [9, 11, 17]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Build with coverage
         run: mvn -B -Pcoverage clean test jacoco:report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2023-02-27
+### Changed
+- Modular JAR: Require at least Java 9 and add a module descriptor (module-info),
+  remove no longer necessary `Automatic-Module-Name` header
+
 ## [0.10.1] - 2022-12-23
 ### Changed
 - Bump maven plugin versions
@@ -76,6 +81,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Initial release!
 
 
+[0.11.0]: https://github.com/robinst/autolink-java/compare/autolink-0.10.1...autolink-0.11.0
 [0.10.1]: https://github.com/robinst/autolink-java/compare/autolink-0.10.0...autolink-0.10.1
 [0.10.0]: https://github.com/robinst/autolink-java/compare/autolink-0.9.0...autolink-0.10.0
 [0.9.0]: https://github.com/robinst/autolink-java/compare/autolink-0.8.0...autolink-0.9.0

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Thanks to [Rinku](https://github.com/vmg/rinku) for the inspiration.
 Usage
 -----
 
-This library is supported on Java 8 or later. It works on Android
+This library is supported on Java 9 or later. It works on Android
 (minimum API level 19). It has no external dependencies.
 
 Maven coordinates

--- a/pom.xml
+++ b/pom.xml
@@ -40,20 +40,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
                 <configuration>
-                    <source>7</source>
-                    <target>7</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>org.nibor.autolink</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.2</version>
+                        <version>0.8.8</version>
                         <executions>
                             <execution>
                                 <id>prepare-agent</id>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module org.nibor.autolink {
+    exports org.nibor.autolink;
+}


### PR DESCRIPTION
Also remove no longer necessary `Automatic-Module-Name` header. Fixes #39.