### PR TITLE
Version 0.12.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Maven Central repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME # env variable to use for username in release
-          server-password: MAVEN_PASSWORD # env variable to use for password in release
+          # See https://central.sonatype.org/publish/publish-portal-maven/
+          server-id: central
+          server-username: CENTRAL_USERNAME # env variable to use for username in release
+          server-password: CENTRAL_PASSWORD # env variable to use for password in release
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable to use for passphrase in release
 
@@ -37,6 +38,6 @@ jobs:
           mvn -B -Dpassword=${{ secrets.GITHUB_TOKEN }} release:prepare
           mvn -B release:perform
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.0] - 2025-06-04
+### Added
+- Include OSGi metadata in jar
+### Changed
 - Require at least Java 11
 
 ## [0.11.0] - 2023-02-27
@@ -84,6 +87,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Initial release!
 
 
+[0.12.0]: https://github.com/robinst/autolink-java/compare/autolink-0.11.0...autolink-0.12.0
 [0.11.0]: https://github.com/robinst/autolink-java/compare/autolink-0.10.1...autolink-0.11.0
 [0.10.1]: https://github.com/robinst/autolink-java/compare/autolink-0.10.0...autolink-0.10.1
 [0.10.0]: https://github.com/robinst/autolink-java/compare/autolink-0.9.0...autolink-0.10.0

--- a/pom.xml
+++ b/pom.xml
@@ -119,16 +119,16 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- https://central.sonatype.org/publish/publish-portal-maven/ -->
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
             <plugin>
@@ -238,13 +238,6 @@
             </build>
         </profile>
     </profiles>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.nibor.autolink</groupId>
     <artifactId>autolink</artifactId>
-    <version>0.11.1-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
 
     <name>autolink-java</name>
     <description>


### PR DESCRIPTION
Also, migrate from OSSRH to Central Publisher Portal

See announcement: https://central.sonatype.org/news/20250326_ossrh_sunset/

Followed the guide here, we'll see if it works: https://central.sonatype.org/publish/publish-portal-maven/