### PR TITLE
Overload the linkTypes method to add the var-args approach

### DIFF
--- a/src/main/java/org/nibor/autolink/LinkExtractor.java
+++ b/src/main/java/org/nibor/autolink/LinkExtractor.java
@@ -94,6 +94,17 @@ public class LinkExtractor {
          * @param linkTypes the link types that should be extracted (by default, all types are extracted)
          * @return this builder
          */
+        public Builder linkTypes(LinkType...linkTypes) {
+            if (linkTypes == null) {
+                throw new NullPointerException("linkTypes must not be null");
+            }
+            return this.linkTypes(Set.of(linkTypes));
+        }
+
+        /**
+         * @param linkTypes the link types that should be extracted (by default, all types are extracted)
+         * @return this builder
+         */
         public Builder linkTypes(Set<LinkType> linkTypes) {
             if (linkTypes == null) {
                 throw new NullPointerException("linkTypes must not be null");

--- a/src/main/java/org/nibor/autolink/LinkExtractor.java
+++ b/src/main/java/org/nibor/autolink/LinkExtractor.java
@@ -94,7 +94,7 @@ public class LinkExtractor {
          * @param linkTypes the link types that should be extracted (by default, all types are extracted)
          * @return this builder
          */
-        public Builder linkTypes(LinkType...linkTypes) {
+        public Builder linkTypes(LinkType... linkTypes) {
             if (linkTypes == null) {
                 throw new NullPointerException("linkTypes must not be null");
             }


### PR DESCRIPTION
I overloaded the method to avoid users having to directly use the `Set` static method.